### PR TITLE
feat: use dependency plugin instead of package goal

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,11 +20,11 @@ if [[ $(git diff origin/$GITHUB_BASE_REF HEAD --name-only | grep pom.xml$ | wc -
 
     cd /github/workspace
     
-    mvn -T 16C -s /maven-settings.xml clean package -DskipTests -Dskip-third-party-bom=false -Dthird-party-bom-scopes="compile|provided|runtime|test"
+    mvn -T 16C -s /maven-settings.xml dependency:list -DoutputAbsoluteArtifactFilename=true -DoutputFile=dependencies.txt -Dsort=true -DexcludeGroupIds=org.camunda.bpm,org.camunda.bpm.dmn,org.camunda.bpm.model,org.camunda.feel -DincludeScopes="compile|provided|runtime|test" -U
     find . -name 'dependencies.txt' -exec rsync -R \{\} /pr \;
 
     git checkout -f origin/$GITHUB_BASE_REF
-    mvn -T 16C -s /maven-settings.xml clean package -DskipTests -Dskip-third-party-bom=false -Dthird-party-bom-scopes="compile|provided|runtime|test"
+    mvn -T 16C -s /maven-settings.xml dependency:list -DoutputAbsoluteArtifactFilename=true -DoutputFile=dependencies.txt -Dsort=true -DexcludeGroupIds=org.camunda.bpm,org.camunda.bpm.dmn,org.camunda.bpm.model,org.camunda.feel -DincludeScopes="compile|provided|runtime|test" -U
 
     find . -name 'dependencies.txt' -exec rsync -R \{\} /base \;
 


### PR DESCRIPTION
* Uses the dependency plugin to gather the required information. This introduces less build time overhead for each module and acquires the same information. This also makes the action more stable since it does not require the package goal to work but rather just gathers dependency information.

related to https://github.com/camunda/team-automation-platform/issues/28